### PR TITLE
Fix inheritance order

### DIFF
--- a/nodes/analysis/correlation.py
+++ b/nodes/analysis/correlation.py
@@ -12,7 +12,7 @@ Correlation_method = namedtuple('CorrelationMethod', ['pearson', 'kendall','spea
 CORRELATIONMETHOD = Correlation_method('pearson','kendall','spearman')
 correlationmethod_items = [(i, i, '') for i in CORRELATIONMETHOD]
 
-class SvMegapolisCorrelation(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisCorrelation(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Correlation
     Tooltip: Correlates a Dataframe using the methods; pearson, kendall, or spearman 

--- a/nodes/analysis/correlation_with.py
+++ b/nodes/analysis/correlation_with.py
@@ -13,7 +13,7 @@ Correlation_method = namedtuple('CorrelationMethod', ['pearson', 'kendall','spea
 CORRELATIONMETHOD = Correlation_method('pearson','kendall','spearman')
 correlationmethod_items = [(i, i, '') for i in CORRELATIONMETHOD]
 
-class SvMegapolisCorrelationWith(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisCorrelationWith(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Correlation With
     Tooltip: Correlates a Dataframe with a Series using the methods; pearson, kendall, or spearman 

--- a/nodes/analysis/dataframe_utils.py
+++ b/nodes/analysis/dataframe_utils.py
@@ -13,7 +13,7 @@ Info_type = namedtuple('InfoType', ['info','head','tail','decribe'])
 INFOTYPE = Info_type('info','head','tail','describe')
 infotype_items = [(i, i, '') for i in INFOTYPE]
 
-class SvMegapolisDataframeUtils(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisDataframeUtils(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Dataframe Utils
     Tooltip: Dataframe Utilits for Exploratory Data Analysis: info, head, tail, and decribe  

--- a/nodes/analysis/dem_terrain_attributes.py
+++ b/nodes/analysis/dem_terrain_attributes.py
@@ -13,7 +13,7 @@ Attribute_type = namedtuple('AttributeType', ['aspect', 'profile_curvature','pla
 ATTRIBUTETYPE = Attribute_type('aspect', 'profile_curvature','planform_curvature','curvature','slope_riserun','slope_degrees','slope_percentage','slope_radians')
 attributetype_items = [(i, i, '') for i in ATTRIBUTETYPE]
 
-class SvMegapolisDemTerrainAttributes(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisDemTerrainAttributes(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Dem Terrain Attributes
     Tooltip: Provides methods for extract Terrain Attributes values: Aspect, Curvature, and Slope. 

--- a/nodes/analysis/get_feature_at.py
+++ b/nodes/analysis/get_feature_at.py
@@ -9,7 +9,7 @@ from sverchok.data_structure import updateNode
 #Megapolis Dependencies
 from megapolis.dependencies import pandas as pd
 
-class SvMegapolisGetFeatureAt(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisGetFeatureAt(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Correlation Matrix
     Tooltip: Get a Feture From a Dataframe at X and y features 

--- a/nodes/analysis/get_feature_index.py
+++ b/nodes/analysis/get_feature_index.py
@@ -9,7 +9,7 @@ from sverchok.data_structure import updateNode
 #Megapolis Dependencies
 from megapolis.dependencies import pandas as pd
 
-class SvMegapolisGetFeatureIndex(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisGetFeatureIndex(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Get Feature Index
     Tooltip: Get a Feature from a Daatframe at index of X and y features 

--- a/nodes/analysis/image_segmentation.py
+++ b/nodes/analysis/image_segmentation.py
@@ -399,7 +399,7 @@ class Detector:
 
 
 
-class SvMegapolisImageSegmentation(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisImageSegmentation(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Image Segmentation
     Tooltip: Image Segmentation

--- a/nodes/analysis/isovists.py
+++ b/nodes/analysis/isovists.py
@@ -12,7 +12,7 @@ from megapolis.dependencies import visilibity as vis
 import math
 
 
-class SvMegapolisIsovists(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisIsovists(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Isovists
     Tooltip: Creates a 2D Isovists based on a 2d Context

--- a/nodes/analysis/linear_model_selection.py
+++ b/nodes/analysis/linear_model_selection.py
@@ -13,7 +13,7 @@ Model_method = namedtuple('ModelMethod', ['linear', 'ransac','ridge','elasticnet
 MODELMETHOD = Model_method('linear','ransac','ridge','elasticnet','lasso')
 modelmethod_items = [(i, i, '') for i in MODELMETHOD]
 
-class SvMegapolisLinearModelSelection(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisLinearModelSelection(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Linear Model Selection
     Tooltip: Selection of a Linear Model: Linear, RANSAC, Ridge, ElasticNet, Lasso 

--- a/nodes/analysis/model_evaluate.py
+++ b/nodes/analysis/model_evaluate.py
@@ -9,7 +9,7 @@ from sverchok.data_structure import updateNode
 
 from megapolis.dependencies import sklearn as skl
 
-class SvMegapolisModelEvaluate(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisModelEvaluate(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Model Evaluate
     Tooltip: Model Evaluate

--- a/nodes/analysis/model_fit.py
+++ b/nodes/analysis/model_fit.py
@@ -9,7 +9,7 @@ from sverchok.data_structure import updateNode
 
 from megapolis.dependencies import sklearn as skl
 
-class SvMegapolisModelFit(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisModelFit(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Model Fit
     Tooltip: Model Fit

--- a/nodes/analysis/model_predict.py
+++ b/nodes/analysis/model_predict.py
@@ -9,7 +9,7 @@ from sverchok.data_structure import updateNode
 
 from megapolis.dependencies import sklearn as skl
 
-class SvMegapolisModelPredict(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisModelPredict(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Model Predict
     Tooltip: Model Predict

--- a/nodes/analysis/network_analyses.py
+++ b/nodes/analysis/network_analyses.py
@@ -16,7 +16,7 @@ Analysis_method = namedtuple('AnalysisMethod', ['closeness_centrality','betweenn
 ANALYSISMETHOD = Analysis_method('closeness_centrality','betweenness_centrality','degree_centrality','basic')
 analysismethod_items = [(i, i, '') for i in ANALYSISMETHOD]
 
-class SvMegapolisNetworkAnalyses(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisNetworkAnalyses(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Network Analyses
     Tooltip: Network Analises: Closeness Centrality and Degree Centrality  

--- a/nodes/analysis/object_detection.py
+++ b/nodes/analysis/object_detection.py
@@ -11,7 +11,7 @@ from subprocess import call
 
 import os
 
-class SvMegapolisObjectDetection(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisObjectDetection(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Object Detection
     Tooltip: Object Dectection (Instance Segmentation using YoloV5)

--- a/nodes/analysis/shortest_path.py
+++ b/nodes/analysis/shortest_path.py
@@ -23,7 +23,7 @@ Path_type = namedtuple('PathType', ['length', 'travel_time'])
 PATHTYPE = Path_type('length','travel_time')
 pathtype_items = [(i, i, '') for i in PATHTYPE]
 
-class SvMegapolisShortestPath(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisShortestPath(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Shortest Path
     Tooltip: Provides shortest path between two points based on lenght or time travel 

--- a/nodes/analysis/whitebox_gis_tools.py
+++ b/nodes/analysis/whitebox_gis_tools.py
@@ -14,7 +14,7 @@ import os, signal
 from megapolis.dependencies import psutil
 
 
-class SvMegapolisWhiteboxGisTools(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisWhiteboxGisTools(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: WhiteboxGisTools
     Tooltip: Opens a Whitebox Tool Window

--- a/nodes/gathering/download_data_url.py
+++ b/nodes/gathering/download_data_url.py
@@ -11,7 +11,7 @@ from megapolis.dependencies import wget
 
 import os
 
-class SvMegapolisDownloadDataUrl(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisDownloadDataUrl(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Download Data Url
 

--- a/nodes/gathering/download_st_imagery.py
+++ b/nodes/gathering/download_st_imagery.py
@@ -25,7 +25,7 @@ import json
 import urllib.request
 
 
-class SvMegapolisDownloadStImagery(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisDownloadStImagery(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Download Street Imagery
     Tooltip: Download Geo-Referenced Mapillary Street Imagery

--- a/nodes/gathering/get_pandas_feature.py
+++ b/nodes/gathering/get_pandas_feature.py
@@ -10,7 +10,7 @@ from sverchok.data_structure import updateNode
 from megapolis.dependencies import pandas as pd
 
 
-class SvMegapolisGetPandasFeature(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisGetPandasFeature(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Get Pandas Feature
     Tooltip: Gets a feature from a pandas series

--- a/nodes/gathering/get_sample_dataframe.py
+++ b/nodes/gathering/get_sample_dataframe.py
@@ -22,7 +22,7 @@ DATAFRAME = Dataframe('iris', 'california_housing','diabetes','digits','wine')
 dataframe_items = [(i, i, '') for i in DATAFRAME]
 
 
-class SvMegapolisGetSampleDataframe(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisGetSampleDataframe(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Get Sample Dataframe
     Tooltip: Get a Dataframe Sample

--- a/nodes/gathering/load_street_network.py
+++ b/nodes/gathering/load_street_network.py
@@ -21,7 +21,7 @@ Network_type = namedtuple('NetworkType', ['all', 'bike','drive','drive_service',
 NETWORKTYPE = Network_type('all', 'bike','drive','drive_service','walk')
 networktype_items = [(i, i, '') for i in NETWORKTYPE]
 
-class SvMegapolisLoadStreetNetwork(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisLoadStreetNetwork(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Load Street Network
     Tooltip: Load Street Network

--- a/nodes/gathering/osm_downloader.py
+++ b/nodes/gathering/osm_downloader.py
@@ -23,7 +23,7 @@ features_items = [(i, i, '') for i in FEATURES]
 
 
 
-class SvMegapolisOSMDownloader(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisOSMDownloader(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: OSM Downloader
     Tooltip: Download an Open Streetmap file

--- a/nodes/gathering/pandas_dataframe.py
+++ b/nodes/gathering/pandas_dataframe.py
@@ -9,7 +9,7 @@ from sverchok.data_structure import updateNode
 from megapolis.dependencies import pandas as pd
 
 
-class SvMegapolisPandasDataframe(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisPandasDataframe(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Pandas Series
     Tooltip: Creates a Pandas Dataframe from a Pandas Series

--- a/nodes/gathering/pandas_series.py
+++ b/nodes/gathering/pandas_series.py
@@ -10,7 +10,7 @@ from sverchok.data_structure import updateNode
 from megapolis.dependencies import pandas as pd
 
 
-class SvMegapolisPandasSeries(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisPandasSeries(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Pandas Series
     Tooltip: Creates a Pandas Series from a list

--- a/nodes/gathering/read_csv.py
+++ b/nodes/gathering/read_csv.py
@@ -12,7 +12,7 @@ from megapolis.dependencies import pandas as pd
 import csv
 
 
-class SvMegapolisReadCsv(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisReadCsv(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Read CSV
     Tooltip: Read CSV file

--- a/nodes/gathering/read_dem.py
+++ b/nodes/gathering/read_dem.py
@@ -15,7 +15,7 @@ def makeFaces(x_shape,y_shape):
     return xy
 
 
-class SvMegapolisReadDem(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisReadDem(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Read DEM
     Tooltip: Read a Digital Elevation Model file (geotiff)

--- a/nodes/gathering/read_gis.py
+++ b/nodes/gathering/read_gis.py
@@ -31,7 +31,7 @@ filetypegis_items = [(i, i, '') for i in FILETYPEGIS]
 
 
 
-class SvMegapolisReadGis(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisReadGis(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Read GIS
     Tooltip: Read GIS file (shapefile,geopackage, and geoJSON)

--- a/nodes/gathering/read_json.py
+++ b/nodes/gathering/read_json.py
@@ -11,7 +11,7 @@ from megapolis.dependencies import pandas as pd
 import json
 
 
-class SvMegapolisReadJson(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisReadJson(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Read JSON
     Tooltip: Read JSON file

--- a/nodes/gathering/read_las.py
+++ b/nodes/gathering/read_las.py
@@ -16,7 +16,7 @@ def getCoordinates(las):
     return coordinates
 
 
-class SvMegapolisReadLas(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisReadLas(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Read LAS
     Tooltip: Read a LAS Point Cloud File 

--- a/nodes/gathering/request_data_api.py
+++ b/nodes/gathering/request_data_api.py
@@ -12,7 +12,7 @@ from datetime import datetime
 
 
 
-class SvMegapolisRequestDataApi(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisRequestDataApi(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Request Data Api
     Tooltip: Request data from an Application Program Interface (API)

--- a/nodes/gathering/split_string.py
+++ b/nodes/gathering/split_string.py
@@ -6,7 +6,7 @@ from sverchok.node_tree import SverchCustomTreeNode
 from sverchok.data_structure import updateNode
 
 
-class SvMegapolisSplitString(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisSplitString(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Split String
     Tooltip: Splits a string into a list

--- a/nodes/generation/colormap.py
+++ b/nodes/generation/colormap.py
@@ -31,7 +31,7 @@ sequential_items = [(i, i, '') for i in SEQUENTIAL]
 
 
 
-class SvMegapolisColormap(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisColormap(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Colormap
     Tooltip: Colormap

--- a/nodes/generation/create_dictionary.py
+++ b/nodes/generation/create_dictionary.py
@@ -7,7 +7,7 @@ from sverchok.data_structure import updateNode
 
 #Megapolis Dependencies
 
-class SvMegapolisCreateDictionary(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisCreateDictionary(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Create Dictionary
     Tooltip: Create Dictionary

--- a/nodes/generation/csv_to_dataframe.py
+++ b/nodes/generation/csv_to_dataframe.py
@@ -10,7 +10,7 @@ from sverchok.data_structure import updateNode
 from megapolis.dependencies import pandas as pd
 
 
-class SvMegapolisCsvToDataframe(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisCsvToDataframe(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: CsvToDataframe
     Tooltip: Creates a Dataframe from Csv File

--- a/nodes/generation/faces_from_vertices.py
+++ b/nodes/generation/faces_from_vertices.py
@@ -13,7 +13,7 @@ def makeFaces(list,x_shape,y_shape):
             list.append([x*x_shape+y,x*x_shape+y+1,(x+1)*x_shape+y+1,(x+1)*x_shape+y])
 
 
-class SvMegapolisFacesFromVertices(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisFacesFromVertices(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: FacesFromVertices
     Tooltip: Faces from Vertices

--- a/nodes/generation/file_to_gdf.py
+++ b/nodes/generation/file_to_gdf.py
@@ -11,7 +11,7 @@ from megapolis.dependencies import geopandas as gpd
 
 
 
-class SvMegapolisFileToGdf(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisFileToGdf(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: FileToGdf
     Tooltip: File To Gdf

--- a/nodes/generation/file_to_geojson.py
+++ b/nodes/generation/file_to_geojson.py
@@ -10,7 +10,7 @@ from sverchok.data_structure import updateNode
 from megapolis.dependencies import geopandas as gpd
 import json
 
-class SvMegapolisFileToGeoJson(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisFileToGeoJson(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: FileToGeoJson
     Tooltip: File To GeoJson

--- a/nodes/generation/get_file_path.py
+++ b/nodes/generation/get_file_path.py
@@ -10,7 +10,7 @@ from sverchok.data_structure import updateNode
 import os
 
 
-class SvMegapolisGetFilePath(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisGetFilePath(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: GetFilePath
     Tooltip: Get File Path

--- a/nodes/generation/lat_lon_to_points.py
+++ b/nodes/generation/lat_lon_to_points.py
@@ -15,7 +15,7 @@ except:
 
 
 
-class SvMegapolisLatLonToPoints(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisLatLonToPoints(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: LatLonToPoints
     Tooltip: Lat-Lon To Points

--- a/nodes/generation/pandas_filter.py
+++ b/nodes/generation/pandas_filter.py
@@ -10,7 +10,7 @@ from sverchok.data_structure import updateNode
 from megapolis.dependencies import pandas as pd
 
 
-class SvMegapolisPandasFilter(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisPandasFilter(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Pandas Filter
     Tooltip: Creates a Pandas Filter

--- a/nodes/generation/pandas_map_feature.py
+++ b/nodes/generation/pandas_map_feature.py
@@ -11,7 +11,7 @@ from megapolis.dependencies import pandas as pd
 import json 
 
 
-class SvMegapolisPandasMapFeature(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisPandasMapFeature(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: PandasMapFeature
     Tooltip: Pandas Map Feature

--- a/nodes/generation/sequential_colormap.py
+++ b/nodes/generation/sequential_colormap.py
@@ -31,7 +31,7 @@ sequential_items = [(i, i, '') for i in SEQUENTIAL]
 
 
 
-class SvMegapolisSequentialColormap(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisSequentialColormap(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Sequential Colormap
     Tooltip: Sequential Colormap

--- a/nodes/generation/transpose_dataframe.py
+++ b/nodes/generation/transpose_dataframe.py
@@ -10,7 +10,7 @@ from sverchok.data_structure import updateNode
 from megapolis.dependencies import pandas as pd
  
 
-class SvMegapolisTransposeDataframe(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisTransposeDataframe(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Transpose Dataframe
     Tooltip: Transpose a Dataframe

--- a/nodes/visualisation/dashboard_bokeh_figure.py
+++ b/nodes/visualisation/dashboard_bokeh_figure.py
@@ -9,7 +9,7 @@ from sverchok.data_structure import updateNode
 #Megapolis Dependencies
 
 
-class SvMegapolisDashboardBokehFigure(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisDashboardBokehFigure(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Dashboard Bokeh Figure
     Tooltip: Dashboard Bokeh Figure

--- a/nodes/visualisation/dashboard_bokeh_plot_chart.py
+++ b/nodes/visualisation/dashboard_bokeh_plot_chart.py
@@ -9,7 +9,7 @@ from sverchok.data_structure import updateNode
 #Megapolis Dependencies
 
 
-class SvMegapolisDashboardBokehPlotChart(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisDashboardBokehPlotChart(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Dashboard Bokeh Plot  Chart
     Tooltip: Dashboard Bokeh Plot Chart

--- a/nodes/visualisation/dashboard_bokeh_plot_line.py
+++ b/nodes/visualisation/dashboard_bokeh_plot_line.py
@@ -9,7 +9,7 @@ from sverchok.data_structure import updateNode
 #Megapolis Dependencies
 
 
-class SvMegapolisDashboardBokehPlotLine(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisDashboardBokehPlotLine(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Dashboard Bokeh Plot Line
     Tooltip: Dashboard Bokeh Plot Line

--- a/nodes/visualisation/dashboard_create_plotly.py
+++ b/nodes/visualisation/dashboard_create_plotly.py
@@ -16,7 +16,7 @@ plottype_items = [(i, i, '') for i in PLOTTYPE]
 #Megapolis Dependencies
 import json 
 
-class SvMegapolisDashboardCreatePlotly(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisDashboardCreatePlotly(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Dashboard Create Plotly
     Tooltip: Dashboard Create Plotly

--- a/nodes/visualisation/dashboard_creation.py
+++ b/nodes/visualisation/dashboard_creation.py
@@ -12,7 +12,7 @@ from megapolis.dependencies import streamlit as st
 import os
 #import json 
 
-class SvMegapolisDashboardCreation(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisDashboardCreation(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Dashboard Creation
     Tooltip: Dashboard Creation

--- a/nodes/visualisation/dashboard_dataframe.py
+++ b/nodes/visualisation/dashboard_dataframe.py
@@ -12,7 +12,7 @@ from megapolis.dependencies import streamlit as st
 
 #import json 
 
-class SvMegapolisDashboardDataframe(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisDashboardDataframe(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Dashboard Dataframe
     Tooltip: Dashboard Dataframe

--- a/nodes/visualisation/dashboard_geojson_to_map.py
+++ b/nodes/visualisation/dashboard_geojson_to_map.py
@@ -9,7 +9,7 @@ from sverchok.data_structure import updateNode
 #Megapolis Dependencies
 import json
 
-class SvMegapolisDashboardGeojsonToMap(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisDashboardGeojsonToMap(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Dashboard Geojson To Map
     Tooltip: Dashboard Geojson to Map

--- a/nodes/visualisation/dashboard_load_map.py
+++ b/nodes/visualisation/dashboard_load_map.py
@@ -9,7 +9,7 @@ from sverchok.data_structure import updateNode
 #Megapolis Dependencies
 
 
-class SvMegapolisDashboardLoadMap(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisDashboardLoadMap(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Dashboard Load Map
     Tooltip: Dashboard Load Map

--- a/nodes/visualisation/dashboard_map.py
+++ b/nodes/visualisation/dashboard_map.py
@@ -9,7 +9,7 @@ from sverchok.data_structure import updateNode
 #Megapolis Dependencies
 
 
-class SvMegapolisDashboardMap(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisDashboardMap(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Dashboard Map
     Tooltip: Dashboard Map

--- a/nodes/visualisation/dashboard_markdown.py
+++ b/nodes/visualisation/dashboard_markdown.py
@@ -7,7 +7,7 @@ from sverchok.data_structure import updateNode
 
 #Megapolis Dependencies
 
-class SvMegapolisDashboardMarkdown(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisDashboardMarkdown(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Dashboard Markdown
     Tooltip: Dashboard Markdown

--- a/nodes/visualisation/dashboard_mesh.py
+++ b/nodes/visualisation/dashboard_mesh.py
@@ -9,7 +9,7 @@ from sverchok.data_structure import updateNode
 #Megapolis Dependencies
 
 
-class SvMegapolisDashboardMesh(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisDashboardMesh(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Dashboard Mesh
     Tooltip: Dashboard Mesh

--- a/nodes/visualisation/dashboard_plotly_figure.py
+++ b/nodes/visualisation/dashboard_plotly_figure.py
@@ -9,7 +9,7 @@ from sverchok.data_structure import updateNode
 #Megapolis Dependencies
 
 
-class SvMegapolisDashboardPlotlyFigure(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisDashboardPlotlyFigure(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Dashboard Plotly Figure
     Tooltip: Dashboard Plotly Figure

--- a/nodes/visualisation/dashboard_plotly_scatter.py
+++ b/nodes/visualisation/dashboard_plotly_scatter.py
@@ -8,7 +8,7 @@ from sverchok.data_structure import updateNode
 #Megapolis Dependencies
 import json 
 
-class SvMegapolisDashboardPlotlyScatter(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisDashboardPlotlyScatter(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Dashboard Plotly Scatter
     Tooltip: Dashboard Plotly Scatter

--- a/nodes/visualisation/dashboard_server.py
+++ b/nodes/visualisation/dashboard_server.py
@@ -14,7 +14,7 @@ import sys
 
 from megapolis.dependencies import psutil
 
-class SvMegapolisDashboardServer(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisDashboardServer(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Dashboard Server
     Tooltip: Dashboard Server

--- a/nodes/visualisation/dataframe_vis.py
+++ b/nodes/visualisation/dataframe_vis.py
@@ -68,7 +68,7 @@ def format_to_text(data):
     return out
 
 
-class SvMegapolisDataframeVis(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisDataframeVis(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Dataframe to Sverchok Text
     Tooltip: Quickly write A Dataframe from NodeView to text datablock

--- a/nodes/visualisation/plot_dem.py
+++ b/nodes/visualisation/plot_dem.py
@@ -22,7 +22,7 @@ SEQUENTIAL = Sequential('viridis', 'plasma', 'inferno', 'magma', 'cividis','Grey
       'Wistia', 'hot', 'afmhot', 'gist_heat', 'copper')
 sequential_items = [(i, i, '') for i in SEQUENTIAL]
 
-class SvMegapolisPlotDem(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisPlotDem(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Plot Dem
     Tooltip: Plot a Dem Array 

--- a/nodes/visualisation/python_server.py
+++ b/nodes/visualisation/python_server.py
@@ -16,7 +16,7 @@ import webbrowser
 
 from megapolis.dependencies import psutil
 
-class SvMegapolisPythonServer(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisPythonServer(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Python Server
     Tooltip: Python Server

--- a/nodes/visualisation/seaborn_plot.py
+++ b/nodes/visualisation/seaborn_plot.py
@@ -26,7 +26,7 @@ Plot = namedtuple('Plot', ['regplot', 'pairplot'])
 PLOT = Plot('regplot', 'pairplot')
 plot_items = [(i, i, '') for i in PLOT]
 
-class SvMegapolisSeabornPlot(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisSeabornPlot(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Seaborn Plot
     Tooltip: Plot

--- a/nodes/visualisation/webvr_connector.py
+++ b/nodes/visualisation/webvr_connector.py
@@ -9,7 +9,7 @@ from sverchok.data_structure import updateNode
 #Megapolis Dependencies
 import os
 
-class SvMegapolisWebVRConnector(bpy.types.Node, SverchCustomTreeNode):
+class SvMegapolisWebVRConnector(SverchCustomTreeNode, bpy.types.Node):
     """
     Triggers: Web VR Connector
     Tooltip: Web VR Connector


### PR DESCRIPTION
Python searches methods from left to right. If method is found the search is stopped. In the case it is searches `poll` class method and it found it in Node class and poll from SverchCustomTreeNode is never used. In Blender 3.4 this causes the nodes to appear in the search of build-in editors.